### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
 
 def check_dependencies():
 
-    return ['numpy', 'scipy', 'matplotlib==2.2.3', 'requests']
+    return ['numpy', 'scipy', 'matplotlib>=2.2.3', 'requests']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed dependencies to require matplotlib>=2.2.3 rather than ==2.2.3. This should avoid unintended downgrading of matplotlib for end users.

#### Sanity

- [x] I'm aware of the implications of the proposed changes
- [x] Code is [PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] I'm making the PR to `master`


#### Tests

- [ ] Changes have gone through actual use testing
- [ ] All local tests have passed (run `python test_script.py`)
- [ ] Tests have been updated to reflect the changes

I have intentionally not performed these tests due to the insignificance of the change.
<hr>
